### PR TITLE
Automatically launch browser and wait for login; remove external tunnel; 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,51 +3,72 @@
 Authentication for td ameritrade api made easy.   
 Initialize once and then reuse the library to get fresh tokens as needed.  
 
-### Initialization  
-Initialilaztion is needed to obtain the initial access token. Once this is obtained, it is stored alongside the refresh token. The library will return the access token as long as it's fresh, and will obtain a new one when it becomes stale.  
+### Configuration
+You must have a developer account with TD Ameritrade (which is free) and you must have created an app.  The instructions for doing this will print the first
+time you attempt run the software.
 
-Initialization is exposed through a cli as well as an api.   
+The default port used by the library is 2828.  You may change this in the init.js file.
 
-cli:
-``` bash
-td-ameritrade-auth init --key=<your-td-app-key>
+Before using the library, you must generate a .key and .crt pair for the HTTPS server.  To do this, you must have one of the many SLL implementations installed.
+Install OpenSSL (or equivalent) if you do not already an sn SSL implementation.
+
+Then in the main folder, execute:
+
+    openssl genrsa 2048 > server.key
+    chmod 400 host.key # not needed on windows
+    openssl req -new -x509 -nodes -sha256 -key server.key -out server.crt
+
+Answer he questions asked and your pair should be created.
+
+
+### Declarations 
+``` javascript
+
+const { init } = require('td-ameritrade-auth');
+const { getToken } = require('td-ameritrade-auth');
 ```
+
+### Initialization  
 
 api:
 ``` javascript
-const { init } = require('td-ameritrade-auth');
 
-init(<your-td-app-key>)
-  .then(() => console.log('done!'))
+await init('8U4VN7I02WNZSL802BYX2PLU86T1LSJPK')  // Sample is meaningless: replace with your APP_ID
+  .then(() => console.log('Token server started'))
   .catch((err) => console.log(err));
 ```
 
-Either way, text will output guiding you through the rest of the process.  
-1. copy the callback url link generated on app boot
-2. update your app in td ameritrade's web ui to accept the callback url generated on app boot
-3. click on the link generated on app boot to login and authorize your app
+Initialization is needed to start the HTTPS server.  Do so near the start of your program.
+
+### Get Token  
+
+api:
+``` javascript
+
+await getToken('8U4VN7I02WNZSL802BYX2PLU86T1LSJPK')  // Sample is meaningless: replace with your APP_ID
+  .then(() => console.log('Got token!'))
+  .catch((err) => console.log(err));
+```
+
+Call this when you need to use a token.   Tokens from TD Ameritrade are valid for 30 minutes only, so the token must be refreshed within that timeframe to avoid outages.  Refresh tokens are valid for 90 days, after which you must log in again.
+
+If the refresh token is expired or you have not yet downloaded a refresh token, instructions will be displayed and the browser will automatically launch.  You must authorize the retrieval of the refresh token by logging into your TD Ameritrade trading account (not your developer account.)
+
+Overview:
+1. copy the callback url link generated on app boot (defaults to https://localhost:2828)
+2. update your app in td ameritrade's developer web site to accept the callback url in step 1.
+
+If you have not yet generated your app, re-run your program to launch to the correct page.
+
+Once your access token is obtained, it is stored alongside the refresh token. The library will return the access token as long as it's fresh, and will obtain a new one when it becomes stale.  
 
 Your access_token, along with refresh_token and expiration times, will be stored in `node_modules/td-ameritrade-auth/src/.tdsecrets`.
 
-### Get Token  
-Once the library has been initialized, it has what it needs to retreive a fresh token. Tokens from TD Ameritrade are valid for 30 minutes only, so the token must be refreshed within that timeframe to avoid outages. 
-
-cli:
-``` bash
-td-ameritrade-auth token --key=<your-td-app-key>
-```
-
-bash:
-``` javascript
-const { getToken } = require('td-ameritrade-auth');
-
-(async () => {
-  const token = await getToken('<your-td-app-key>');
-})()
-```
 
 ### App Key
 Your app key is referred to in a number of different ways throughout the TD Ameritrade docs. I have tried to keep it consistent in the code base here as well as the docs.  
 The docs call it a consumer key, an oauth user id, an api key. For the purposes of this project is considered an app key.
+
+The app key will look like this: 8U4VN7I02WNZSL802BYX2PLU86T1LSJPK
 
 That being said, each function optionally accepts the app key as a function parameter, but it call also be exposed as an environment variabe `TDAUTH_APPKEY`.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const init = require('./src/init');
+const { init, login } = require('./src/init');
 const getToken = require('./src/token');
 
 module.exports = { init, getToken };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "debug": "^4.1.1",
     "express": "^4.17.1",
     "moment": "^2.25.3",
-    "ngrok": "^3.2.7",
+    "open": "^8.0.2",
     "request": "^2.88.2",
     "request-promise": "^4.2.5",
     "supports-color": "^7.1.0"

--- a/src/init.js
+++ b/src/init.js
@@ -1,11 +1,42 @@
-const { promises: fs } = require('fs');
+var fs = require('fs');
+const { promises: pfs } = require('fs');
+var https = require('https');
+var privateKey = fs.readFileSync('server.key', 'utf8');
+var certificate = fs.readFileSync('server.crt', 'utf8');
+var credentials = { key: privateKey, cert: certificate };
 const ngrok = require('ngrok');
 const express = require('express');
 const rp = require('request-promise');
 const moment = require('moment');
 const { secretsfile } = require('./constants');
+const Open = require('open');
 
+// Choose the port you would like to use for your server
 const port = 2828;
+const callbackUrl = `https://localhost:` + port;
+
+const eventsSharedBuffer = new SharedArrayBuffer(4); // we only a single event.  Automatically initialized to 0 by constructor.
+const events = new Int32Array(eventsSharedBuffer);
+
+var clientId;
+
+async function login(appkeyparam) {
+    console.log("No token available.  Requesting one from user.")
+
+    await Open(`https://auth.tdameritrade.com/auth?response_type=code&redirect_uri=${encodeURI(callbackUrl)}&client_id=${encodeURI(clientId)}`)
+
+    console.log(`
+Opening browser for login and awaiting connection from TD Ameritrade...
+
+If you get an error in your browers, you have not yet created an app in your TD Ameritrade Developer account:
+
+Login to your developer account here: https://developer.tdameritrade.com/
+            Then, create an app here: https://developer.tdameritrade.com/user/me/apps
+          ...using this callback URL: ${callbackUrl}
+        `);
+    // Don't block the message thread --- keep 
+    while (Atomics.load(events, 0) == 0) await new Promise(resolve => setTimeout(resolve, 100));
+}
 
 async function init(appkeyparam) {
   const appkey = appkeyparam || process.env.TDAUTH_APPKEY;
@@ -13,15 +44,10 @@ async function init(appkeyparam) {
     throw new Error('app key must be passed into init function or set as TDAUTH_APPKEY environment variable');
   }
 
-  const clientId = `${appkey}@AMER.OAUTHAP`;
-
-  const url = await ngrok.connect({
-    addr: port,
-  });
-  const callbackUrl = `${url}/cb`;
+    clientId = `${appkey}@AMER.OAUTHAP`;
 
   const app = express();
-  app.get('/cb', async (req, res, next) => {
+  app.get('/', async (req, res, next) => {
     try {
       const { code } = req.query;
       const options = {
@@ -39,13 +65,11 @@ async function init(appkeyparam) {
       };
       const data = await rp(options);
       data.now = moment().unix();
-      await fs.writeFile(secretsfile, JSON.stringify(data, null, 2));
-      res.json({ ok: 'ok', data });
-      console.log(`
-        Thank you for initializing td-ameritrade-auth.
-        The library is ready to use, and getToken should now return an up to date access_token as needed.
-      `);
-      return process.exit(0);
+            await pfs.writeFile(secretsfile, JSON.stringify(data, null, 2));
+            res.send('Your key has been recorded and you may now close this window.');
+            console.log("notifying");
+            Atomics.store(events, 0, 1);
+            Atomics.notify(events, 0, 1);
     } catch (err) {
       return next(err);
     }
@@ -58,25 +82,15 @@ async function init(appkeyparam) {
   });
 
   return new Promise((resolve, reject) => {
-    app.listen(port, (err) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-
-      console.log(`
-        Navigate to your app settings in TD Ameritrade and set the callback url to ${callbackUrl}.
-
-
-        Apps:           https://developer.tdameritrade.com/user/me/apps
-        Callback URL:   ${callbackUrl}
-       
-
-        Once the app has been configured, navigate to the following address to authenticate your application:
-        https://auth.tdameritrade.com/auth?response_type=code&redirect_uri=${encodeURI(callbackUrl)}&client_id=${encodeURI(clientId)}
-      `);
+        httpsServer=https.createServer(credentials, app);
+        httpsServer.listen(port, (err) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+        });
+        resolve();
     });
-  });
 }
 
-module.exports = init;
+module.exports = { init, login };

--- a/src/init.js
+++ b/src/init.js
@@ -4,7 +4,6 @@ const https = require('https');
 const privateKey = fs.readFileSync('server.key', 'utf8');
 const certificate = fs.readFileSync('server.crt', 'utf8');
 const credentials = { key: privateKey, cert: certificate };
-const ngrok = require('ngrok');
 const express = require('express');
 const rp = require('request-promise');
 const moment = require('moment');

--- a/src/init.js
+++ b/src/init.js
@@ -1,9 +1,9 @@
-var fs = require('fs');
+const fs = require('fs');
 const { promises: pfs } = require('fs');
-var https = require('https');
-var privateKey = fs.readFileSync('server.key', 'utf8');
-var certificate = fs.readFileSync('server.crt', 'utf8');
-var credentials = { key: privateKey, cert: certificate };
+const https = require('https');
+const privateKey = fs.readFileSync('server.key', 'utf8');
+const certificate = fs.readFileSync('server.crt', 'utf8');
+const credentials = { key: privateKey, cert: certificate };
 const ngrok = require('ngrok');
 const express = require('express');
 const rp = require('request-promise');

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,45 +38,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@types/caseless@*":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
-  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
-"@types/node@*":
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.1.tgz#5d93e0a099cd0acd5ef3d5bde3c086e1f49ff68c"
-  integrity sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==
-
-"@types/node@^8.10.50":
-  version "8.10.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.60.tgz#73eb4d1e1c8aa5dc724363b57db019cf28863ef7"
-  integrity sha512-YjPbypHFuiOV0bTgeF07HpEEqhmHaZqYNSdCKeBJa+yFoQ/7BC+FpJcwmi34xUIIRVFktnUyP1dPU8U0612GOg==
-
-"@types/request@^2.48.2":
-  version "2.48.4"
-  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.4.tgz#df3d43d7b9ed3550feaa1286c6eabf0738e6cf7e"
-  integrity sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==
-  dependencies:
-    "@types/caseless" "*"
-    "@types/node" "*"
-    "@types/tough-cookie" "*"
-    form-data "^2.5.0"
-
-"@types/tough-cookie@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
-  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
-
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
 accepts@~1.3.7:
   version "1.3.7"
@@ -229,14 +194,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-binary@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
-  integrity sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=
-  dependencies:
-    buffers "~0.1.1"
-    chainsaw "~0.1.0"
-
 bluebird@^3.5.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -266,11 +223,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-buffers@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
-  integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
-
 bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
@@ -285,13 +237,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
-chainsaw@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
-  integrity sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=
-  dependencies:
-    traverse ">=0.3.0 <0.4"
 
 chalk@^2.0.0, chalk@^2.1.0:
   version "2.4.2"
@@ -410,7 +355,7 @@ core-js-pure@^3.0.0:
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
-core-util-is@1.0.2, core-util-is@~1.0.0:
+core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -452,23 +397,15 @@ debug@^4.0.1, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-decompress-zip@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/decompress-zip/-/decompress-zip-0.3.2.tgz#f3fa2841666abce394604f4a9e8a7085c202d464"
-  integrity sha512-Ab1QY4LrWMrUuo53lLnmGOby7v8ryqxJ+bKibKSiPisx+25mhut1dScVBXAYx14i/PqSrFZvR2FRRazhLbvL+g==
-  dependencies:
-    binary "^0.3.0"
-    graceful-fs "^4.1.3"
-    mkpath "^0.1.0"
-    nopt "^3.0.1"
-    q "^1.1.2"
-    readable-stream "^1.1.8"
-    touch "0.0.3"
-
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -913,15 +850,6 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@^2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
-
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -989,7 +917,7 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.3:
+graceful-fs@^4.1.2:
   version "4.2.4"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -1098,7 +1026,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@~2.0.1:
+inherits@2, inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1156,6 +1084,11 @@ is-date-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
   integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
+  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -1202,10 +1135,12 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@^1.0.0:
   version "1.0.0"
@@ -1372,11 +1307,6 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-mkpath@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/mkpath/-/mkpath-0.1.0.tgz#7554a6f8d871834cc97b5462b122c4c124d6de91"
-  integrity sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=
-
 moment@^2.25.3:
   version "2.25.3"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.25.3.tgz#252ff41319cf41e47761a1a88cab30edfe9808c0"
@@ -1412,36 +1342,10 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-ngrok@^3.2.7:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/ngrok/-/ngrok-3.2.7.tgz#774e66b4c8c56bae2c95e9859ea046844d03d03c"
-  integrity sha512-B7K15HM0qRZplL2aO/yfxixYubH0M50Pfu0fa4PDcmXP7RC+wyYzu6YtX77BBHHCfbwCzkObX6YdO8ThpCR6Lg==
-  dependencies:
-    "@types/node" "^8.10.50"
-    "@types/request" "^2.48.2"
-    decompress-zip "^0.3.2"
-    request "^2.88.0"
-    request-promise-native "^1.0.7"
-    uuid "^3.3.2"
-
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-nopt@^3.0.1:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
-  integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
-  dependencies:
-    abbrev "1"
-
-nopt@~1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
-  integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
-  dependencies:
-    abbrev "1"
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -1533,6 +1437,15 @@ onetime@^5.1.0:
   integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.0.2.tgz#8c3e95cce93ba2fc8d99968ee8bfefecdb50b84f"
+  integrity sha512-NV5QmWJrTaNBLHABJyrb+nd5dXI5zfea/suWawBhkHzAbVhLLiJdrqMgxMypGK9Eznp2Ltoh7SAVkQ3XAucX7Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 optionator@^0.8.3:
   version "0.8.3"
@@ -1675,11 +1588,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-q@^1.1.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
-  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
-
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
@@ -1727,16 +1635,6 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^1.1.8:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
@@ -1762,15 +1660,6 @@ request-promise-core@1.1.3:
   dependencies:
     lodash "^4.17.15"
 
-request-promise-native@^1.0.7:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
-  integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
-  dependencies:
-    request-promise-core "1.1.3"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
 request-promise@^4.2.5:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.5.tgz#186222c59ae512f3497dfe4d75a9c8461bd0053c"
@@ -1781,7 +1670,7 @@ request-promise@^4.2.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.88.0, request@^2.88.2:
+request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -2059,11 +1948,6 @@ string.prototype.trimstart@^1.0.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
-
 strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
@@ -2134,13 +2018,6 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-touch@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/touch/-/touch-0.0.3.tgz#51aef3d449571d4f287a5d87c9c8b49181a0db1d"
-  integrity sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=
-  dependencies:
-    nopt "~1.0.10"
-
 tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -2148,11 +2025,6 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   dependencies:
     psl "^1.1.28"
     punycode "^2.1.1"
-
-"traverse@>=0.3.0 <0.4":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
-  integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
 
 tslib@^1.9.0:
   version "1.12.0"


### PR DESCRIPTION
**This is a minor rewrite offered for your consideration.**

**Changes**:

1. Removed the ngrok service (because running a major financial access key through a non-open-source uncontrolled 3rd party server makes me uncomfortable) and replaced it with a localhost HTTPS server.  (No tunnel is needed anyway --- the local browser has access to the local computer.)
2. Calling init now only starts the HTTPS server.
3. Calling token will automatically display instructions and launch the browser if no token is currently available, or if the existing token is stale.  The program will wait until the user logs in, then get the key and continue.

NOTES:
_You MUST provide a .crt and .key file for the HTTPS server to run properly.  Install OpenSSL (or equivalent) if you do not already an sn SSL implementation._

    openssl genrsa 2048 > server.key
    chmod 400 host.key # not needed on windows
    openssl req -new -x509 -nodes -sha256 -key server.key -out server.crt

You should always call init at the start of your program.  Call getToken when you need it; the browser will automatically launch if required:

    await init('RDXO55TZCJS4LGIEOF5MDRHMCZVNSFP8B')  // replace with your APP_ID
        .then(console.log("Token server started"))
        .catch((err) => console.log(err));

Then, when you need to use a token:

    TDtoken = await getToken('RDXO55TZCJS4LGIEOF5MDRHMCZVNSFP8B')  // replace with your APP_ID
        .then(console.log("Got token"))
        .catch((err) => console.log(err));


